### PR TITLE
Add simple web UI and Windows scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ This project aims to build a simple web application that simulates football matc
    ```bash
    flask run --app app
    ```
+   On Windows you can use `start.bat` which will create a virtual environment
+   if necessary and start the server automatically.
 
 ## Running the App
-With the server running you can access these endpoints:
+With the server running you can open `http://127.0.0.1:5000/` in your browser
+to use a small test interface. The API exposes these endpoints:
 
 - `GET /teams` lists all teams with their current ELO rating.
 - `POST /simulate` simulates a match. Send JSON with `team_a`, `team_b` and
@@ -35,6 +38,9 @@ curl -X POST http://127.0.0.1:5000/simulate \
   -H "Content-Type: application/json" \
   -d '{"team_a": "Germany", "team_b": "Brazil", "result": 1}'
 ```
+
+To update dependencies later run `update.bat` (Windows) or reinstall from
+`requirements.txt`.
 
 ## Future Improvements
 - Add a frontend interface for easier team selection and match simulation

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,8 @@
+@echo off
+REM Setup virtual environment and start the Flask server
+if not exist venv (
+    python -m venv venv
+)
+call venv\Scripts\activate
+pip install -r requirements.txt
+flask run --app app

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Football Elo Simulator</title>
+</head>
+<body>
+  <h1>Football Elo Simulator</h1>
+  <div>
+    <label>Team A:</label>
+    <select id="team_a"></select>
+  </div>
+  <div>
+    <label>Team B:</label>
+    <select id="team_b"></select>
+  </div>
+  <div>
+    <label>Result:</label>
+    <select id="result">
+      <option value="1">Team A Win</option>
+      <option value="0.5">Draw</option>
+      <option value="0">Team B Win</option>
+    </select>
+  </div>
+  <button onclick="simulate()">Simulate</button>
+  <pre id="output"></pre>
+<script>
+async function loadTeams() {
+  const res = await fetch('/teams');
+  const teams = await res.json();
+  const selA = document.getElementById('team_a');
+  const selB = document.getElementById('team_b');
+  Object.keys(teams).forEach(team => {
+    const optA = document.createElement('option');
+    optA.value = team;
+    optA.text = team;
+    selA.appendChild(optA);
+    const optB = document.createElement('option');
+    optB.value = team;
+    optB.text = team;
+    selB.appendChild(optB);
+  });
+}
+async function simulate() {
+  const teamA = document.getElementById('team_a').value;
+  const teamB = document.getElementById('team_b').value;
+  const result = parseFloat(document.getElementById('result').value);
+  const res = await fetch('/simulate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ team_a: teamA, team_b: teamB, result })
+  });
+  const data = await res.json();
+  document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+}
+loadTeams();
+</script>
+</body>
+</html>

--- a/update.bat
+++ b/update.bat
@@ -1,0 +1,8 @@
+@echo off
+REM Update dependencies inside the virtual environment
+if exist venv (
+    call venv\Scripts\activate
+    pip install --upgrade -r requirements.txt
+) else (
+    echo Virtual environment not found. Run start.bat first.
+)


### PR DESCRIPTION
## Summary
- add CSV loader and root route to `app.py`
- create basic HTML interface in `templates/index.html`
- provide Windows helper scripts `start.bat` and `update.bat`
- document usage in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py elo.py`
- `pycodestyle app.py elo.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684098e98de4832b92c38d8b4295b7de